### PR TITLE
Pinning only major version

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "mpifx" %}
 {% set version = "1.5" %}
-{% set build = 0 %}
+{% set build = 1 %}
 {% set mpi = mpi or "nompi" %}
 
 package:
@@ -19,7 +19,8 @@ build:
   string: {{ mpi_prefix }}_h{{ PKG_HASH }}_{{ build }}
 
   run_exports:
-    - {{ pin_subpackage(name, max_pin='x.x') }} {{ mpi_prefix }}_*
+    # MpiFx uses semantic versioning, it should be enough to pin major version number only.
+    - {{ pin_subpackage(name, max_pin='x') }} {{ mpi_prefix }}_*
 
 requirements:
   build:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)
* [X] ~Reset the build number to `0` (if the version changed)~
* [X] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [X] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

mpifx was fixed to minor version number when used as dependency. This lead to problems for the DFTB+ package, where the direct mpifx dependency clashed with the indirect one via libnegf as they required different minor version numbers. Since MpiFx is semantically versioned, pinning major version number should be enough.

<!--
Please add any other relevant info below:
-->
